### PR TITLE
 Better privacy by fragmenting SNI clientHello

### DIFF
--- a/cmd/tlsrouter/config.go
+++ b/cmd/tlsrouter/config.go
@@ -69,8 +69,10 @@ func (c *Config) Match(hostname string) (string, bool) {
 	}
 
 	for _, r := range c.routes {
-		if r.match.MatchString(hostname) {
-			return r.backend, r.proxyInfo
+		matches := r.match.FindStringSubmatchIndex(hostname)
+		if matches != nil {
+			result := r.match.ExpandString(nil, r.backend, hostname, matches)
+			return string(result), r.proxyInfo
 		}
 	}
 	return "", false


### PR DESCRIPTION
Implement better privacy of `tlsrouter` by fragmenting SNI clientHello.
This should prevent high-traffic DPI snooping.

Add feature to use regex capture groups for dynamic routing.

Both features used together can circumvent some forms of censorship by ISP.

# Breakdown
- [x] Add tcp fragmentation / segmentation of `clientHello` for better privacy (enabled by default)
- [x] Expand regex capture groups for dynamic routing. See below.

# Example config:
```
/(.+)\.oca\.nflxvideo\.net$/    $1.oca.nflxvideo.net:443
/(?P<subdomain>.+)\.oca\.nflxvideo\.net$/    ${subdomain}.oca.nflxvideo.net:443
```
